### PR TITLE
Add Connection.from_url

### DIFF
--- a/tinysmtp.py
+++ b/tinysmtp.py
@@ -1,4 +1,5 @@
 import smtplib
+from urlparse import urlparse
 from email.encoders import encode_base64
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
@@ -29,6 +30,12 @@ class Connection(object):
         self.ssl = ssl or env('TINYSMTP_SSL')
         self.tls = tls or env('TINYSMTP_TLS')
         self.debug = debug or env('TINYSMTP_DEBUG')
+    
+    @classmethod
+    def from_url(cls, url, *args, **kwargs):
+        url = urlparse(url)
+        assert url.scheme == 'smtp' or not url.scheme
+        return cls(url.hostname, url.port, url.username, url.password, *args, **kwargs)
 
     def connect(self):
         SMTP = smtplib.SMTP_SSL if self.ssl else smtplib.SMTP

--- a/tinysmtp.py
+++ b/tinysmtp.py
@@ -24,7 +24,7 @@ class Connection(object):
     def __init__(self, hostname=None, port=None, username=None, password=None,
                  ssl=False, tls=False, debug=False):
         self.hostname = hostname or env('TINYSMTP_SERVER')
-        self.port = env('TINYSMTP_PORT', default=25)
+        self.port = port or env('TINYSMTP_PORT', default=25)
         self.username = username or env('TINYSMTP_USERNAME')
         self.password = password or env('TINYSMTP_PASSWORD')
         self.ssl = ssl or env('TINYSMTP_SSL')


### PR DESCRIPTION
These days many "cloud" services are specified using a URL format, like databases and most other services on Heroku. Configuration this way is a lot cleaner than setting _four_ separate environment variables.

```
smtp://username:password@smtp.gmail.com:587
```

See this project for example: https://github.com/danielfarrell/smtp_url
